### PR TITLE
Chromeのシークレットウィンドウ内のiframeで利用した場合にnuxtが起動しない問題への対応

### DIFF
--- a/lib/plugin.client.js
+++ b/lib/plugin.client.js
@@ -153,46 +153,50 @@ class HistoryState {
         this._route = null;
         this._validated = false;
 
-        if (window.sessionStorage) {
-            const backupText = sessionStorage.getItem('nuxt-history-state');
-            if (backupText) {
-                sessionStorage.removeItem('nuxt-history-state');
-                try {
-                    const backupState = JSON.parse(LZString.decompress(backupText));
-                    this._action = 'reload';
-                    this._page = backupState[0];
-                    this._items = backupState[1];
+        try {
+            if (window.sessionStorage) {
+                const backupText = sessionStorage.getItem('nuxt-history-state');
+                if (backupText) {
+                    sessionStorage.removeItem('nuxt-history-state');
+                    try {
+                        const backupState = JSON.parse(LZString.decompress(backupText));
+                        this._action = 'reload';
+                        this._page = backupState[0];
+                        this._items = backupState[1];
 
-                    if (reloadable) {
-                        const query = parseQuery(window.location.search);
-                        const page = parseInt(query && query['_p'], 10);
-                        if (page == null || Number.isNaN(page)) {
-                            this._action = 'navigate';
-                            this._page = this._page + 1;
-                            this._items.length = this._page + 1;
-                            this._items[this._page] = [];
+                        if (reloadable) {
+                            const query = parseQuery(window.location.search);
+                            const page = parseInt(query && query['_p'], 10);
+                            if (page == null || Number.isNaN(page)) {
+                                this._action = 'navigate';
+                                this._page = this._page + 1;
+                                this._items.length = this._page + 1;
+                                this._items[this._page] = [];
+                            }
                         }
+                    } catch (error) {
+                        this._action = 'invalid';
+                        console.error('Failed to restore from sessionStorage.', error);
                     }
-                } catch (error) {
+                } else if (getNavigationType() !== 'navigate') {
                     this._action = 'invalid';
-                    console.error('Failed to restore from sessionStorage.', error);
+                    console.error('The saved history state is not found.');
                 }
-            } else if (getNavigationType() !== 'navigate') {
-                this._action = 'invalid';
-                console.error('The saved history state is not found.');
+
+                window.addEventListener('unload', event => {
+                    this._save();
+                    try {
+                        sessionStorage.setItem('nuxt-history-state', LZString.compress(JSON.stringify([
+                            this._page,
+                            this._items
+                        ])));
+                    } catch (error) {
+                        console.error('Failed to save to sessionStorage.', error);
+                    }
+                });
             }
-            
-            window.addEventListener('unload', event => {
-                this._save();
-                try {
-                    sessionStorage.setItem('nuxt-history-state', LZString.compress(JSON.stringify([
-                        this._page,
-                        this._items
-                    ])));
-                } catch (error) {
-                    console.error('Failed to save to sessionStorage.', error);
-                }
-            });
+        } catch (error) {
+            console.error('Failed to access to sessionStorage.', error);
         }
 
         if (!reloadable && this._action !== 'invalid') {


### PR DESCRIPTION
タイトルの通り、Chrome等のシークレットウィンドウかつiframe環境で別ドメインページとしてnuxtページを開こうとするとエラーでnuxtjsが起動しなくなってしまいます。
原因はサードパーティCookieのブロックが有効(シークレットウィンドウではデフォルトで有効です)な時にwindow.sessionStorageに触ろうとすると以下のエラーが発生するためです。
```
Uncaught DOMException: Failed to read the 'sessionStorage' property from 'Window': Access is denied for this document.
```
コード上ではsessionStorage自体は存在をチェックされていたので、プルリクエストでは該当部分をtry-catchで囲むことでエラー対応しました。
お手数ですが内容ご確認いただけると幸いです。